### PR TITLE
test(e2e, playwright): added e2e test for /todo list command

### DIFF
--- a/e2e/playwright/package.json
+++ b/e2e/playwright/package.json
@@ -2,7 +2,7 @@
     "name": "plugin-e2e-tests",
     "scripts": {
         "test": "PW_SLOMO=200 npm run test --prefix ../../../mattermost/e2e-tests/playwright -- --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts'",
-        "test-ui": "PW_SLOMO=200 npm run test --prefix ../../../mattermost/e2e-tests/playwright -- --ui --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts'",
+        "test-ui": "PW_SLOMO=200 npm run test --prefix ../../../mattermost/e2e-tests/playwright -- --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts' --ui",
         "test-ci": "PW_HEADLESS=true npm test",
         "test-slomo": "npm run test-slomo --prefix ../../../mattermost/e2e-tests/playwright -- --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts",
         "debug": "npm test -- --debug",

--- a/e2e/playwright/package.json
+++ b/e2e/playwright/package.json
@@ -2,6 +2,7 @@
     "name": "plugin-e2e-tests",
     "scripts": {
         "test": "PW_SLOMO=200 npm run test --prefix ../../../mattermost/e2e-tests/playwright -- --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts'",
+        "test-ui": "PW_SLOMO=200 npm run test --prefix ../../../mattermost/e2e-tests/playwright -- --ui --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts'",
         "test-ci": "PW_HEADLESS=true npm test",
         "test-slomo": "npm run test-slomo --prefix ../../../mattermost/e2e-tests/playwright -- --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts",
         "debug": "npm test -- --debug",

--- a/e2e/playwright/support/utils.ts
+++ b/e2e/playwright/support/utils.ts
@@ -3,8 +3,8 @@
 
 import type {Page} from '@playwright/test';
 
-import {UserProfile} from '@mattermost/types/users';
 import Client4 from '@mattermost/client/client4';
+import {UserProfile} from '@mattermost/types/users';
 
 export const waitForNewMessages = async (page: Page) => {
     await page.waitForTimeout(1000);
@@ -57,4 +57,10 @@ export const getSlackAttachmentLocatorId = (postId: string) => {
 
 export const getPostMessageLocatorId = (postId: string) => {
     return `#post_${postId} .post-message`;
+};
+
+export const getLastPost = async (page: Page) => {
+  const lastPost = page.getByTestId("postView").last();
+  await lastPost.waitFor();
+  return lastPost;
 };

--- a/e2e/playwright/tests/test.list.ts
+++ b/e2e/playwright/tests/test.list.ts
@@ -1,10 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import { test } from "@playwright/test";
-import core from "./todo_plugin.spec";
+import {test} from '@playwright/test';
+import core from './todo_plugin.spec';
 
-import "../support/init_test";
+import '../support/init_test';
 
 // Test if plugin is setup correctly
 test.describe("setup", core.setup);

--- a/e2e/playwright/tests/test.list.ts
+++ b/e2e/playwright/tests/test.list.ts
@@ -6,4 +6,8 @@ import core from "./todo_plugin.spec";
 
 import "../support/init_test";
 
+// Test if plugin is setup correctly
 test.describe("setup", core.setup);
+
+// Test various plugin actions
+test.describe("actions", core.actions);

--- a/e2e/playwright/tests/test.list.ts
+++ b/e2e/playwright/tests/test.list.ts
@@ -10,4 +10,4 @@ import '../support/init_test';
 test.describe("setup", core.setup);
 
 // Test various plugin actions
-test.describe("actions", core.actions);
+test.describe("actions", core.commands);

--- a/e2e/playwright/tests/test.list.ts
+++ b/e2e/playwright/tests/test.list.ts
@@ -1,9 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {test} from '@playwright/test';
-import core from './todo_plugin.spec';
+import { test } from "@playwright/test";
+import core from "./todo_plugin.spec";
 
-import '../support/init_test';
+import "../support/init_test";
 
-test.describe(core.connected);
+test.describe("setup", core.setup);

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -6,76 +6,72 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-import { expect, test } from "@e2e-support/test_fixture";
-import SlashCommandSuggestions from "support/components/slash_commands";
-import { fillMessage, getTodoBotDMPageURL } from "support/utils";
+import {expect, test} from '@e2e-support/test_fixture';
+import SlashCommandSuggestions from 'support/components/slash_commands';
+import {fillMessage, getLastPost, getTodoBotDMPageURL, postMessage, } from 'support/utils';
 
 test.beforeEach(async ({ page, pw }) => {
-  const { adminClient, adminUser } = await pw.getAdminClient();
+  const {adminClient, adminUser} = await pw.getAdminClient();
   if (adminUser === null) {
-    throw new Error("can not get adminUser");
+    throw new Error('can not get adminUser');
   }
-  const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
-  await page.goto(dmURL, { waitUntil: "load" });
+  const dmURL = await getTodoBotDMPageURL(adminClient, '', adminUser.id);
+  await page.goto(dmURL, {waitUntil: 'load'});
 });
 
 export default {
   setup: () => {
-    test("checking available commands", async ({ pages, page, pw }) => {
-      const slash = new SlashCommandSuggestions(
-        page.locator("#suggestionList")
-      );
+    test('checking available commands', async ({ page }) => {
+      const slash = new SlashCommandSuggestions(page.locator('#suggestionList'));
 
       // # Run command to trigger todo
-      await fillMessage("/todo", page);
+      await fillMessage('/todo', page);
 
       // * Assert suggestions are visible
       await expect(slash.container).toBeVisible();
 
       // * Assert todo [command] is visible
-      await expect(slash.getItemTitleNth(0)).toHaveText("todo [command]");
+      await expect(slash.getItemTitleNth(0)).toHaveText('todo [command]');
 
-      await expect(slash.getItemDescNth(0)).toHaveText(
-        "Available commands: list, add, pop, send, settings, help"
-      );
+      await expect(slash.getItemDescNth(0)).toHaveText('Available commands: list, add, pop, send, settings, help');
     });
   },
-  actions: () => {
-    test("help action", async ({ pages, page, pw }) => {
+  commands: () => {
+    test('help', async ({ pages, page, pw }) => {
       const c = new pages.ChannelsPage(page);
 
       // # Run command to trigger help
-      await c.postMessage("/todo help");
+      postMessage('/todo help', page);
 
       // # Grab the last post
-      const post = await c.getLastPost();
-      const postBody = post.container.locator(".post-message__text-container");
+      const post = await getLastPost(page);
+      const postBody = post.locator('.post-message__text-container');
 
       // * Assert /todo add [message] command is visible
-      await expect(postBody).toContainText(`add [message]`);
+      await expect(postBody).toContainText('add [message]');
 
       // * Assert /todo list command is visible
-      await expect(postBody).toContainText("list");
+      await expect(postBody).toContainText('list');
 
       // * Assert /todo list [listName] command is visible
-      await expect(postBody).toContainText("list [listName]");
+      await expect(postBody).toContainText('list [listName]');
 
       // * Assert /todo pop command is visible
-      await expect(postBody).toContainText("pop");
+      await expect(postBody).toContainText('pop');
 
       // * Assert /todo send [user] [message] command is visible
-      await expect(postBody).toContainText("send [user] [message]");
+      await expect(postBody).toContainText('send [user] [message]');
 
       // * Assert /todo settings summary [on, off] command is visible
-      await expect(postBody).toContainText("settings summary [on, off]");
+      await expect(postBody).toContainText('settings summary [on, off]');
 
       // * Assert /todo settings allow_incoming_task_requests [on, off] command is visible
       await expect(postBody).toContainText(
-        "settings allow_incoming_task_requests [on, off]"
+        'settings allow_incoming_task_requests [on, off]'
       );
 
       // * Assert /todo help command is visible
-      await expect(postBody).toContainText("help");
+      await expect(postBody).toContainText('help');
     });
 
     test("list action", async ({ pages, page, pw }) => {
@@ -113,3 +109,4 @@ export default {
     });
   },
 };
+

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -22,7 +22,6 @@ test.beforeEach(async ({ page, pw }) => {
 export default {
   setup: () => {
     test("checking available commands", async ({ pages, page, pw }) => {
-      const c = new pages.ChannelsPage(page);
       const slash = new SlashCommandSuggestions(
         page.locator("#suggestionList")
       );
@@ -44,9 +43,6 @@ export default {
   actions: () => {
     test("help action", async ({ pages, page, pw }) => {
       const c = new pages.ChannelsPage(page);
-      const slash = new SlashCommandSuggestions(
-        page.locator("#suggestionList")
-      );
 
       // # Run command to trigger help
       await c.postMessage("/todo help");

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -77,5 +77,39 @@ export default {
       // * Assert /todo help command is visible
       await expect(postBody).toContainText("help");
     });
+
+    test("list action", async ({ pages, page, pw }) => {
+      const c = new pages.ChannelsPage(page);
+      const slash = new SlashCommandSuggestions(
+        page.locator("#suggestionList")
+      );
+      const todoMessage = "Don't forget to be awesome";
+
+      // # Run command to add todo
+      await c.postMessage(`/todo add ${todoMessage}`);
+
+      // # Type command to list todo
+      await fillMessage("/todo list ", page);
+
+      // * Assert suggestions are visible
+      await expect(slash.container).toBeVisible();
+      await expect(slash.getItemTitleNth(1)).toHaveText("in (optional)");
+      await expect(slash.getItemDescNth(1)).toHaveText("Received Todos");
+      await expect(slash.getItemTitleNth(2)).toHaveText("out (optional)");
+      await expect(slash.getItemDescNth(2)).toHaveText("Sent Todos");
+
+      // # Run command to list todo
+      await c.postMessage(`/todo list`);
+
+      // # Grab the last post
+      const post = await c.getLastPost();
+      const postBody = post.container.locator(".post-message__text-container");
+
+      // * Assert post body has correct title
+      await expect(postBody).toContainText("Todo List:");
+
+      // * Assert added todo is visible
+      await expect(postBody).toContainText(todoMessage);
+    });
   },
 };

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -8,7 +8,7 @@
 
 import {expect, test} from '@e2e-support/test_fixture';
 import SlashCommandSuggestions from 'support/components/slash_commands';
-import {fillMessage, getLastPost, getTodoBotDMPageURL, postMessage, } from 'support/utils';
+import {fillMessage, getLastPost, getTodoBotDMPageURL, postMessage} from 'support/utils';
 
 test.beforeEach(async ({ page, pw }) => {
   const {adminClient, adminUser} = await pw.getAdminClient();
@@ -37,56 +37,18 @@ export default {
     });
   },
   commands: () => {
-    test('help', async ({ pages, page, pw }) => {
-      const c = new pages.ChannelsPage(page);
-
-      // # Run command to trigger help
-      postMessage('/todo help', page);
-
-      // # Grab the last post
-      const post = await getLastPost(page);
-      const postBody = post.locator('.post-message__text-container');
-
-      // * Assert /todo add [message] command is visible
-      await expect(postBody).toContainText('add [message]');
-
-      // * Assert /todo list command is visible
-      await expect(postBody).toContainText('list');
-
-      // * Assert /todo list [listName] command is visible
-      await expect(postBody).toContainText('list [listName]');
-
-      // * Assert /todo pop command is visible
-      await expect(postBody).toContainText('pop');
-
-      // * Assert /todo send [user] [message] command is visible
-      await expect(postBody).toContainText('send [user] [message]');
-
-      // * Assert /todo settings summary [on, off] command is visible
-      await expect(postBody).toContainText('settings summary [on, off]');
-
-      // * Assert /todo settings allow_incoming_task_requests [on, off] command is visible
-      await expect(postBody).toContainText(
-        'settings allow_incoming_task_requests [on, off]'
-      );
-
-      // * Assert /todo help command is visible
-      await expect(postBody).toContainText('help');
-    });
-
     test("list action", async ({ pages, page, pw }) => {
       const c = new pages.ChannelsPage(page);
-      const slash = new SlashCommandSuggestions(
-        page.locator("#suggestionList")
-      );
       const todoMessage = "Don't forget to be awesome";
 
       // # Run command to add todo
-      await c.postMessage(`/todo add ${todoMessage}`);
+      postMessage(`/todo add ${todoMessage}`, page);
 
       // # Type command to list todo
       await fillMessage("/todo list ", page);
-
+      const slash = new SlashCommandSuggestions(
+        page.locator("#suggestionList")
+      );
       // * Assert suggestions are visible
       await expect(slash.container).toBeVisible();
       await expect(slash.getItemTitleNth(1)).toHaveText("in (optional)");
@@ -95,11 +57,11 @@ export default {
       await expect(slash.getItemDescNth(2)).toHaveText("Sent Todos");
 
       // # Run command to list todo
-      await c.postMessage(`/todo list`);
+      await postMessage('/todo list', page);
 
       // # Grab the last post
-      const post = await c.getLastPost();
-      const postBody = post.container.locator(".post-message__text-container");
+      const post = await getLastPost(page);
+      const postBody = post.locator(".post-message__text-container");
 
       // * Assert post body has correct title
       await expect(postBody).toContainText("Todo List:");

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -7,17 +7,11 @@
 // ***************************************************************
 
 import { expect, test } from "@e2e-support/test_fixture";
-import Client4 from "@mattermost/client/client4";
-import { UserProfile } from "@mattermost/types/users";
 import SlashCommandSuggestions from "support/components/slash_commands";
 import { fillMessage, getTodoBotDMPageURL } from "support/utils";
 
-let adminClient: Client4, adminUser: UserProfile | null;
-
 test.beforeEach(async ({ page, pw }) => {
-  const data = await pw.getAdminClient();
-  adminClient = data.adminClient;
-  adminUser = data.adminUser;
+  const { adminClient, adminUser } = await pw.getAdminClient();
   if (adminUser === null) {
     throw new Error("can not get adminUser");
   }
@@ -28,74 +22,64 @@ test.beforeEach(async ({ page, pw }) => {
 export default {
   setup: () => {
     test("checking available commands", async ({ pages, page, pw }) => {
-      if (adminUser) {
-        const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
-        await page.goto(dmURL, { waitUntil: "load" });
-        const c = new pages.ChannelsPage(page);
-        const slash = new SlashCommandSuggestions(
-          page.locator("#suggestionList")
-        );
+      const c = new pages.ChannelsPage(page);
+      const slash = new SlashCommandSuggestions(
+        page.locator("#suggestionList")
+      );
 
-        // # Run command to trigger todo
-        await fillMessage("/todo", page);
+      // # Run command to trigger todo
+      await fillMessage("/todo", page);
 
-        // * Assert suggestions are visible
-        await expect(slash.container).toBeVisible();
+      // * Assert suggestions are visible
+      await expect(slash.container).toBeVisible();
 
-        // * Assert todo [command] is visible
-        await expect(slash.getItemTitleNth(0)).toHaveText("todo [command]");
+      // * Assert todo [command] is visible
+      await expect(slash.getItemTitleNth(0)).toHaveText("todo [command]");
 
-        await expect(slash.getItemDescNth(0)).toHaveText(
-          "Available commands: list, add, pop, send, settings, help"
-        );
-      }
+      await expect(slash.getItemDescNth(0)).toHaveText(
+        "Available commands: list, add, pop, send, settings, help"
+      );
     });
   },
   actions: () => {
     test("help action", async ({ pages, page, pw }) => {
-      if (adminUser) {
-        const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
-        await page.goto(dmURL, { waitUntil: "load" });
-        const c = new pages.ChannelsPage(page);
-        const slash = new SlashCommandSuggestions(
-          page.locator("#suggestionList")
-        );
+      const c = new pages.ChannelsPage(page);
+      const slash = new SlashCommandSuggestions(
+        page.locator("#suggestionList")
+      );
 
-        // # Run command to trigger help
-        await c.postMessage("/todo help");
+      // # Run command to trigger help
+      await c.postMessage("/todo help");
 
-        // # Grab the last post
-        const post = await c.getLastPost();
-        const postBody = post.container.locator(
-          ".post-message__text-container"
-        );
+      // # Grab the last post
+      const post = await c.getLastPost();
+      const postBody = post.container.locator(".post-message__text-container");
 
-        // * Assert /todo add [message] command is visible
-        await expect(postBody).toContainText(`add [message]`);
+      // * Assert /todo add [message] command is visible
+      await expect(postBody).toContainText(`add [message]`);
 
-        // * Assert /todo list command is visible
-        await expect(postBody).toContainText("list");
+      // * Assert /todo list command is visible
+      await expect(postBody).toContainText("list");
 
-        // * Assert /todo list [listName] command is visible
-        await expect(postBody).toContainText("list [listName]");
+      // * Assert /todo list [listName] command is visible
+      await expect(postBody).toContainText("list [listName]");
 
-        // * Assert /todo pop command is visible
-        await expect(postBody).toContainText("pop");
+      // * Assert /todo pop command is visible
+      await expect(postBody).toContainText("pop");
 
-        // * Assert /todo send [user] [message] command is visible
-        await expect(postBody).toContainText("send [user] [message]");
+      // * Assert /todo send [user] [message] command is visible
+      await expect(postBody).toContainText("send [user] [message]");
 
-        // * Assert /todo settings summary [on, off] command is visible
-        await expect(postBody).toContainText("settings summary [on, off]");
+      // * Assert /todo settings summary [on, off] command is visible
+      await expect(postBody).toContainText("settings summary [on, off]");
 
-        // * Assert /todo settings allow_incoming_task_requests [on, off] command is visible
-        await expect(postBody).toContainText(
-          "settings allow_incoming_task_requests [on, off]"
-        );
+      // * Assert /todo settings allow_incoming_task_requests [on, off] command is visible
+      await expect(postBody).toContainText(
+        "settings allow_incoming_task_requests [on, off]"
+      );
 
-        // * Assert /todo help command is visible
-        await expect(postBody).toContainText("help");
-      }
+      // * Assert /todo help command is visible
+      await expect(postBody).toContainText("help");
     });
   },
 };

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -7,36 +7,95 @@
 // ***************************************************************
 
 import { expect, test } from "@e2e-support/test_fixture";
+import Client4 from "@mattermost/client/client4";
+import { UserProfile } from "@mattermost/types/users";
 import SlashCommandSuggestions from "support/components/slash_commands";
 import { fillMessage, getTodoBotDMPageURL } from "support/utils";
+
+let adminClient: Client4, adminUser: UserProfile | null;
+
+test.beforeEach(async ({ page, pw }) => {
+  const data = await pw.getAdminClient();
+  adminClient = data.adminClient;
+  adminUser = data.adminUser;
+  if (adminUser === null) {
+    throw new Error("can not get adminUser");
+  }
+  const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
+  await page.goto(dmURL, { waitUntil: "load" });
+});
 
 export default {
   setup: () => {
     test("checking available commands", async ({ pages, page, pw }) => {
-      const { adminClient, adminUser } = await pw.getAdminClient();
-      if (adminUser === null) {
-        throw new Error("can not get adminUser");
+      if (adminUser) {
+        const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
+        await page.goto(dmURL, { waitUntil: "load" });
+        const c = new pages.ChannelsPage(page);
+        const slash = new SlashCommandSuggestions(
+          page.locator("#suggestionList")
+        );
+
+        // # Run command to trigger todo
+        await fillMessage("/todo", page);
+
+        // * Assert suggestions are visible
+        await expect(slash.container).toBeVisible();
+
+        // * Assert todo [command] is visible
+        await expect(slash.getItemTitleNth(0)).toHaveText("todo [command]");
+
+        await expect(slash.getItemDescNth(0)).toHaveText(
+          "Available commands: list, add, pop, send, settings, help"
+        );
       }
-      const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
-      await page.goto(dmURL, { waitUntil: "load" });
+    });
+  },
+  actions: () => {
+    test("help action", async ({ pages, page, pw }) => {
+      if (adminUser) {
+        const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
+        await page.goto(dmURL, { waitUntil: "load" });
+        const c = new pages.ChannelsPage(page);
+        const slash = new SlashCommandSuggestions(
+          page.locator("#suggestionList")
+        );
 
-      const c = new pages.ChannelsPage(page);
-      const slash = new SlashCommandSuggestions(
-        page.locator("#suggestionList")
-      );
+        // # Run command to trigger help
+        await c.postMessage("/todo help");
 
-      // # Run incomplete command to trigger help
-      await fillMessage("/todo", page);
+        // # Grab the last post
+        const post = await c.getLastPost();
+        const postBody = post.container.locator(
+          ".post-message__text-container"
+        );
 
-      // * Assert suggestions are visible
-      await expect(slash.container).toBeVisible();
+        // * Assert /todo add [message] command is visible
+        await expect(postBody).toContainText(`add [message]`);
 
-      // * Assert help is visible
-      await expect(slash.getItemTitleNth(0)).toHaveText("todo [command]");
+        // * Assert /todo list command is visible
+        await expect(postBody).toContainText("list");
 
-      await expect(slash.getItemDescNth(0)).toHaveText(
-        "Available commands: list, add, pop, send, settings, help"
-      );
+        // * Assert /todo list [listName] command is visible
+        await expect(postBody).toContainText("list [listName]");
+
+        // * Assert /todo pop command is visible
+        await expect(postBody).toContainText("pop");
+
+        // * Assert /todo send [user] [message] command is visible
+        await expect(postBody).toContainText("send [user] [message]");
+
+        // * Assert /todo settings summary [on, off] command is visible
+        await expect(postBody).toContainText("settings summary [on, off]");
+
+        // * Assert /todo settings allow_incoming_task_requests [on, off] command is visible
+        await expect(postBody).toContainText(
+          "settings allow_incoming_task_requests [on, off]"
+        );
+
+        // * Assert /todo help command is visible
+        await expect(postBody).toContainText("help");
+      }
     });
   },
 };

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -6,37 +6,37 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-import {expect, test} from '@e2e-support/test_fixture';
-import SlashCommandSuggestions from 'support/components/slash_commands';
-import {fillMessage, getTodoBotDMPageURL} from 'support/utils';
+import { expect, test } from "@e2e-support/test_fixture";
+import SlashCommandSuggestions from "support/components/slash_commands";
+import { fillMessage, getTodoBotDMPageURL } from "support/utils";
 
 export default {
-    connected: () => {
-        test.describe('available commands', () => {
-            test('with just the main command', async ({pages, page, pw}) => {
-               
-            const {adminClient, adminUser} = await pw.getAdminClient();
-            if (adminUser === null) {
-                throw new Error('can not get adminUser');
-            }
-            const dmURL = await getTodoBotDMPageURL(adminClient, '', adminUser.id);
-            await page.goto(dmURL, {waitUntil: 'load'});
+  setup: () => {
+    test("checking available commands", async ({ pages, page, pw }) => {
+      const { adminClient, adminUser } = await pw.getAdminClient();
+      if (adminUser === null) {
+        throw new Error("can not get adminUser");
+      }
+      const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
+      await page.goto(dmURL, { waitUntil: "load" });
 
-            const c = new pages.ChannelsPage(page);
-            const slash = new SlashCommandSuggestions(page.locator('#suggestionList'));
+      const c = new pages.ChannelsPage(page);
+      const slash = new SlashCommandSuggestions(
+        page.locator("#suggestionList")
+      );
 
-            // # Run incomplete command to trigger help
-            await fillMessage('/todo', page);
+      // # Run incomplete command to trigger help
+      await fillMessage("/todo", page);
 
-            // * Assert suggestions are visible
-            await expect(slash.container).toBeVisible();
+      // * Assert suggestions are visible
+      await expect(slash.container).toBeVisible();
 
-            // * Assert help is visible
-            await expect(slash.getItemTitleNth(0)).toHaveText('todo [command]');
+      // * Assert help is visible
+      await expect(slash.getItemTitleNth(0)).toHaveText("todo [command]");
 
-            await expect(slash.getItemDescNth(0)).toHaveText('Available commands: list, add, pop, send, settings, help');
-            });
-        });
-    },
+      await expect(slash.getItemDescNth(0)).toHaveText(
+        "Available commands: list, add, pop, send, settings, help"
+      );
+    });
+  },
 };
-


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This introduces a Playwright end-to-end (e2e) test to check if the `/todo list` command functions as expected. We verify that the correct suggestions are shown and then assert by listing a previously added todo.

I've also made a few changes to improve clarity and readability.
Verified that the test passes locally.

<img width="643" alt="image" src="https://github.com/mattermost/mattermost-plugin-todo/assets/22114682/ca0a5fc7-d725-452a-8100-ef9db324729b">
