### PR TITLE
test(e2e, playwright): added e2e test for /todo add command

### DIFF
--- a/e2e/playwright/package.json
+++ b/e2e/playwright/package.json
@@ -2,7 +2,7 @@
     "name": "plugin-e2e-tests",
     "scripts": {
         "test": "PW_SLOMO=200 npm run test --prefix ../../../mattermost/e2e-tests/playwright -- --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts'",
-        "test-ui": "PW_SLOMO=200 npm run test --prefix ../../../mattermost/e2e-tests/playwright -- --ui --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts'",
+        "test-ui": "PW_SLOMO=200 npm run test --prefix ../../../mattermost/e2e-tests/playwright -- --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts' --ui",
         "test-ci": "PW_HEADLESS=true npm test",
         "test-slomo": "npm run test-slomo --prefix ../../../mattermost/e2e-tests/playwright -- --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts",
         "debug": "npm test -- --debug",

--- a/e2e/playwright/package.json
+++ b/e2e/playwright/package.json
@@ -2,6 +2,7 @@
     "name": "plugin-e2e-tests",
     "scripts": {
         "test": "PW_SLOMO=200 npm run test --prefix ../../../mattermost/e2e-tests/playwright -- --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts'",
+        "test-ui": "PW_SLOMO=200 npm run test --prefix ../../../mattermost/e2e-tests/playwright -- --ui --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts'",
         "test-ci": "PW_HEADLESS=true npm test",
         "test-slomo": "npm run test-slomo --prefix ../../../mattermost/e2e-tests/playwright -- --project=chrome --config='../../../mattermost-plugin-todo/e2e/playwright/playwright.config.ts",
         "debug": "npm test -- --debug",

--- a/e2e/playwright/tests/test.list.ts
+++ b/e2e/playwright/tests/test.list.ts
@@ -6,4 +6,8 @@ import core from "./todo_plugin.spec";
 
 import "../support/init_test";
 
+// Test if plugin is setup correctly
 test.describe("setup", core.setup);
+
+// Test various plugin actions
+test.describe("actions", core.actions);

--- a/e2e/playwright/tests/test.list.ts
+++ b/e2e/playwright/tests/test.list.ts
@@ -1,9 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {test} from '@playwright/test';
-import core from './todo_plugin.spec';
+import { test } from "@playwright/test";
+import core from "./todo_plugin.spec";
 
-import '../support/init_test';
+import "../support/init_test";
 
-test.describe(core.connected);
+test.describe("setup", core.setup);

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -22,7 +22,6 @@ test.beforeEach(async ({ page, pw }) => {
 export default {
   setup: () => {
     test("checking available commands", async ({ pages, page, pw }) => {
-      const c = new pages.ChannelsPage(page);
       const slash = new SlashCommandSuggestions(
         page.locator("#suggestionList")
       );
@@ -44,9 +43,6 @@ export default {
   actions: () => {
     test("help action", async ({ pages, page, pw }) => {
       const c = new pages.ChannelsPage(page);
-      const slash = new SlashCommandSuggestions(
-        page.locator("#suggestionList")
-      );
 
       // # Run command to trigger help
       await c.postMessage("/todo help");

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -7,17 +7,11 @@
 // ***************************************************************
 
 import { expect, test } from "@e2e-support/test_fixture";
-import Client4 from "@mattermost/client/client4";
-import { UserProfile } from "@mattermost/types/users";
 import SlashCommandSuggestions from "support/components/slash_commands";
 import { fillMessage, getTodoBotDMPageURL } from "support/utils";
 
-let adminClient: Client4, adminUser: UserProfile | null;
-
 test.beforeEach(async ({ page, pw }) => {
-  const data = await pw.getAdminClient();
-  adminClient = data.adminClient;
-  adminUser = data.adminUser;
+  const { adminClient, adminUser } = await pw.getAdminClient();
   if (adminUser === null) {
     throw new Error("can not get adminUser");
   }
@@ -28,74 +22,64 @@ test.beforeEach(async ({ page, pw }) => {
 export default {
   setup: () => {
     test("checking available commands", async ({ pages, page, pw }) => {
-      if (adminUser) {
-        const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
-        await page.goto(dmURL, { waitUntil: "load" });
-        const c = new pages.ChannelsPage(page);
-        const slash = new SlashCommandSuggestions(
-          page.locator("#suggestionList")
-        );
+      const c = new pages.ChannelsPage(page);
+      const slash = new SlashCommandSuggestions(
+        page.locator("#suggestionList")
+      );
 
-        // # Run command to trigger todo
-        await fillMessage("/todo", page);
+      // # Run command to trigger todo
+      await fillMessage("/todo", page);
 
-        // * Assert suggestions are visible
-        await expect(slash.container).toBeVisible();
+      // * Assert suggestions are visible
+      await expect(slash.container).toBeVisible();
 
-        // * Assert todo [command] is visible
-        await expect(slash.getItemTitleNth(0)).toHaveText("todo [command]");
+      // * Assert todo [command] is visible
+      await expect(slash.getItemTitleNth(0)).toHaveText("todo [command]");
 
-        await expect(slash.getItemDescNth(0)).toHaveText(
-          "Available commands: list, add, pop, send, settings, help"
-        );
-      }
+      await expect(slash.getItemDescNth(0)).toHaveText(
+        "Available commands: list, add, pop, send, settings, help"
+      );
     });
   },
   actions: () => {
     test("help action", async ({ pages, page, pw }) => {
-      if (adminUser) {
-        const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
-        await page.goto(dmURL, { waitUntil: "load" });
-        const c = new pages.ChannelsPage(page);
-        const slash = new SlashCommandSuggestions(
-          page.locator("#suggestionList")
-        );
+      const c = new pages.ChannelsPage(page);
+      const slash = new SlashCommandSuggestions(
+        page.locator("#suggestionList")
+      );
 
-        // # Run command to trigger help
-        await c.postMessage("/todo help");
+      // # Run command to trigger help
+      await c.postMessage("/todo help");
 
-        // # Grab the last post
-        const post = await c.getLastPost();
-        const postBody = post.container.locator(
-          ".post-message__text-container"
-        );
+      // # Grab the last post
+      const post = await c.getLastPost();
+      const postBody = post.container.locator(".post-message__text-container");
 
-        // * Assert /todo add [message] command is visible
-        await expect(postBody).toContainText(`add [message]`);
+      // * Assert /todo add [message] command is visible
+      await expect(postBody).toContainText(`add [message]`);
 
-        // * Assert /todo list command is visible
-        await expect(postBody).toContainText("list");
+      // * Assert /todo list command is visible
+      await expect(postBody).toContainText("list");
 
-        // * Assert /todo list [listName] command is visible
-        await expect(postBody).toContainText("list [listName]");
+      // * Assert /todo list [listName] command is visible
+      await expect(postBody).toContainText("list [listName]");
 
-        // * Assert /todo pop command is visible
-        await expect(postBody).toContainText("pop");
+      // * Assert /todo pop command is visible
+      await expect(postBody).toContainText("pop");
 
-        // * Assert /todo send [user] [message] command is visible
-        await expect(postBody).toContainText("send [user] [message]");
+      // * Assert /todo send [user] [message] command is visible
+      await expect(postBody).toContainText("send [user] [message]");
 
-        // * Assert /todo settings summary [on, off] command is visible
-        await expect(postBody).toContainText("settings summary [on, off]");
+      // * Assert /todo settings summary [on, off] command is visible
+      await expect(postBody).toContainText("settings summary [on, off]");
 
-        // * Assert /todo settings allow_incoming_task_requests [on, off] command is visible
-        await expect(postBody).toContainText(
-          "settings allow_incoming_task_requests [on, off]"
-        );
+      // * Assert /todo settings allow_incoming_task_requests [on, off] command is visible
+      await expect(postBody).toContainText(
+        "settings allow_incoming_task_requests [on, off]"
+      );
 
-        // * Assert /todo help command is visible
-        await expect(postBody).toContainText("help");
-      }
+      // * Assert /todo help command is visible
+      await expect(postBody).toContainText("help");
     });
   },
 };

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -77,5 +77,26 @@ export default {
       // * Assert /todo help command is visible
       await expect(postBody).toContainText("help");
     });
+
+    test("add action", async ({ pages, page, pw }) => {
+      const c = new pages.ChannelsPage(page);
+      const slash = new SlashCommandSuggestions(
+        page.locator("#suggestionList")
+      );
+      const todoMessage = "Don't forget to be awesome";
+
+      // # Run command to add todo
+      await c.postMessage(`/todo add ${todoMessage}`);
+
+      // # Grab the last post
+      const post = await c.getLastPost();
+      const postBody = post.container.locator(".post-message__text-container");
+
+      // * Assert post body has correct title
+      await expect(postBody).toContainText("Added Todo. Todo List:");
+
+      // * Assert added todo is visible
+      await expect(postBody).toContainText(todoMessage);
+    });
   },
 };

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -7,36 +7,95 @@
 // ***************************************************************
 
 import { expect, test } from "@e2e-support/test_fixture";
+import Client4 from "@mattermost/client/client4";
+import { UserProfile } from "@mattermost/types/users";
 import SlashCommandSuggestions from "support/components/slash_commands";
 import { fillMessage, getTodoBotDMPageURL } from "support/utils";
+
+let adminClient: Client4, adminUser: UserProfile | null;
+
+test.beforeEach(async ({ page, pw }) => {
+  const data = await pw.getAdminClient();
+  adminClient = data.adminClient;
+  adminUser = data.adminUser;
+  if (adminUser === null) {
+    throw new Error("can not get adminUser");
+  }
+  const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
+  await page.goto(dmURL, { waitUntil: "load" });
+});
 
 export default {
   setup: () => {
     test("checking available commands", async ({ pages, page, pw }) => {
-      const { adminClient, adminUser } = await pw.getAdminClient();
-      if (adminUser === null) {
-        throw new Error("can not get adminUser");
+      if (adminUser) {
+        const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
+        await page.goto(dmURL, { waitUntil: "load" });
+        const c = new pages.ChannelsPage(page);
+        const slash = new SlashCommandSuggestions(
+          page.locator("#suggestionList")
+        );
+
+        // # Run command to trigger todo
+        await fillMessage("/todo", page);
+
+        // * Assert suggestions are visible
+        await expect(slash.container).toBeVisible();
+
+        // * Assert todo [command] is visible
+        await expect(slash.getItemTitleNth(0)).toHaveText("todo [command]");
+
+        await expect(slash.getItemDescNth(0)).toHaveText(
+          "Available commands: list, add, pop, send, settings, help"
+        );
       }
-      const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
-      await page.goto(dmURL, { waitUntil: "load" });
+    });
+  },
+  actions: () => {
+    test("help action", async ({ pages, page, pw }) => {
+      if (adminUser) {
+        const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
+        await page.goto(dmURL, { waitUntil: "load" });
+        const c = new pages.ChannelsPage(page);
+        const slash = new SlashCommandSuggestions(
+          page.locator("#suggestionList")
+        );
 
-      const c = new pages.ChannelsPage(page);
-      const slash = new SlashCommandSuggestions(
-        page.locator("#suggestionList")
-      );
+        // # Run command to trigger help
+        await c.postMessage("/todo help");
 
-      // # Run incomplete command to trigger help
-      await fillMessage("/todo", page);
+        // # Grab the last post
+        const post = await c.getLastPost();
+        const postBody = post.container.locator(
+          ".post-message__text-container"
+        );
 
-      // * Assert suggestions are visible
-      await expect(slash.container).toBeVisible();
+        // * Assert /todo add [message] command is visible
+        await expect(postBody).toContainText(`add [message]`);
 
-      // * Assert help is visible
-      await expect(slash.getItemTitleNth(0)).toHaveText("todo [command]");
+        // * Assert /todo list command is visible
+        await expect(postBody).toContainText("list");
 
-      await expect(slash.getItemDescNth(0)).toHaveText(
-        "Available commands: list, add, pop, send, settings, help"
-      );
+        // * Assert /todo list [listName] command is visible
+        await expect(postBody).toContainText("list [listName]");
+
+        // * Assert /todo pop command is visible
+        await expect(postBody).toContainText("pop");
+
+        // * Assert /todo send [user] [message] command is visible
+        await expect(postBody).toContainText("send [user] [message]");
+
+        // * Assert /todo settings summary [on, off] command is visible
+        await expect(postBody).toContainText("settings summary [on, off]");
+
+        // * Assert /todo settings allow_incoming_task_requests [on, off] command is visible
+        await expect(postBody).toContainText(
+          "settings allow_incoming_task_requests [on, off]"
+        );
+
+        // * Assert /todo help command is visible
+        await expect(postBody).toContainText("help");
+      }
     });
   },
 };

--- a/e2e/playwright/tests/todo_plugin.spec.ts
+++ b/e2e/playwright/tests/todo_plugin.spec.ts
@@ -6,37 +6,37 @@
 // - [*] indicates an assertion (e.g. * Check the title)
 // ***************************************************************
 
-import {expect, test} from '@e2e-support/test_fixture';
-import SlashCommandSuggestions from 'support/components/slash_commands';
-import {fillMessage, getTodoBotDMPageURL} from 'support/utils';
+import { expect, test } from "@e2e-support/test_fixture";
+import SlashCommandSuggestions from "support/components/slash_commands";
+import { fillMessage, getTodoBotDMPageURL } from "support/utils";
 
 export default {
-    connected: () => {
-        test.describe('available commands', () => {
-            test('with just the main command', async ({pages, page, pw}) => {
-               
-            const {adminClient, adminUser} = await pw.getAdminClient();
-            if (adminUser === null) {
-                throw new Error('can not get adminUser');
-            }
-            const dmURL = await getTodoBotDMPageURL(adminClient, '', adminUser.id);
-            await page.goto(dmURL, {waitUntil: 'load'});
+  setup: () => {
+    test("checking available commands", async ({ pages, page, pw }) => {
+      const { adminClient, adminUser } = await pw.getAdminClient();
+      if (adminUser === null) {
+        throw new Error("can not get adminUser");
+      }
+      const dmURL = await getTodoBotDMPageURL(adminClient, "", adminUser.id);
+      await page.goto(dmURL, { waitUntil: "load" });
 
-            const c = new pages.ChannelsPage(page);
-            const slash = new SlashCommandSuggestions(page.locator('#suggestionList'));
+      const c = new pages.ChannelsPage(page);
+      const slash = new SlashCommandSuggestions(
+        page.locator("#suggestionList")
+      );
 
-            // # Run incomplete command to trigger help
-            await fillMessage('/todo', page);
+      // # Run incomplete command to trigger help
+      await fillMessage("/todo", page);
 
-            // * Assert suggestions are visible
-            await expect(slash.container).toBeVisible();
+      // * Assert suggestions are visible
+      await expect(slash.container).toBeVisible();
 
-            // * Assert help is visible
-            await expect(slash.getItemTitleNth(0)).toHaveText('todo [command]');
+      // * Assert help is visible
+      await expect(slash.getItemTitleNth(0)).toHaveText("todo [command]");
 
-            await expect(slash.getItemDescNth(0)).toHaveText('Available commands: list, add, pop, send, settings, help');
-            });
-        });
-    },
+      await expect(slash.getItemDescNth(0)).toHaveText(
+        "Available commands: list, add, pop, send, settings, help"
+      );
+    });
+  },
 };
-


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This introduces a Playwright end-to-end (e2e) test to check if the `/todo add` command functions as expected. We verify this by adding a todo and asserting the content.

I've also made a few changes to improve clarity and readability.
Verified that the test passes locally.

<img width="674" alt="image" src="https://github.com/mattermost/mattermost-plugin-todo/assets/22114682/d31e2235-228e-45a0-b80b-8b313acb4b81">


